### PR TITLE
Add e2e tests for publishing plug-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ https://www.scala-sbt.org/1.x/docs/Testing-sbt-plugins.html
 sbt scripted
 sbt "scripted read/work"
 sbt "scripted read/fail"
+sbt "scripted write/work"
 ```
 
 # Target aspects of the plug-in

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers+= "Artifactory" at "https://wudong.jfrog.io/artifactory/default-maven-local"
 
 libraryDependencies += {
-  "io.github.esbeetee" % "sbt-consistent_2.12_1.0" % "0.4.4"
+  "io.github.esbeetee" % "sbt-consistent_2.12_1.0" % "0.4.5"
 }
 
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")

--- a/src/sbt-test/read/work/build.sbt
+++ b/src/sbt-test/read/work/build.sbt
@@ -5,8 +5,11 @@ import sbtconsistent.SbtConsistentPlugin.addConsistentSbtPlugin
 // this should work because sbt-assembly is published consistently
 // addSbtCons("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 // import sbtconsistent.SbtConsistentPlugin.addConsistentSbtPlugin
-addConsistentSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
-//addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
+addConsistentSbtPlugin("io.github.esbeetee" % "sbt-consistent" % "0.4.7")
+
+// currently the sbt-consistent plugin is published to the following artifactory.
+// will change to maven center later.
+resolvers+= "artifactory" at "https://wudong.jfrog.io/artifactory/default-maven-local"
 
 TaskKey[Unit]("check") := {
   val updateResult = update.result.value
@@ -15,12 +18,12 @@ TaskKey[Unit]("check") := {
     s"Expected success, got: ${updateResult}",
   )
   updateResult.toEither.toSeq.flatMap(_.toVector)
-    .find(_.toString.contains("sbt-assembly")) match {
+    .find(_.toString.contains("sbt-consistent")) match {
     case None => sys
-        .error(s"Could not find sbt-assembly artifact, have: ${updateResult}")
+        .error(s"Could not find sbt-consistent artifact, have: ${updateResult}")
     case Some(artifact)
         if artifact.toString.contains(
-          """sbt-assembly_sbt1_2.12/1.2.0/sbt-assembly_sbt1_2.12-1.2.0.jar""",
+          """sbt-consistent_2.12_1.0/0.4.7/sbt-consistent_2.12_1.0-0.4.7.jar""",
         ) => ()
     case Some(artifact) => sys.error(s"Unexpected artifact found: ${artifact}")
   }

--- a/src/sbt-test/write/consistent/build.sbt
+++ b/src/sbt-test/write/consistent/build.sbt
@@ -2,7 +2,9 @@ import sbtconsistent.SbtConsistentPlugin.addConsistentSbtPlugin
 // cannot use the addSbtPlugin method cause it will add additional attributes which causes problems resolving.
 // we way want to use it as a global plugin when use it within enterprise.
 
-lazy val currentV = s"0.0.2${scala.util.Random.nextInt()}-SNAPSHOT"
+// cannot use a random number here, it appear each step in the test script,
+// starts with a new sbt process, cause we got different random number between publish / check.
+lazy val currentV = "0.0.312345156"
 
 ThisBuild / version := currentV
 
@@ -29,7 +31,7 @@ TaskKey[Unit]("check") := {
         .error(s"Could not find test-plugin artifact, have: $updateResult")
     case Some(artifact)
         if artifact.toString.contains(
-          s"""test-plugin_sbt1_2.12/0.0.2-SNAPSHOT/test-plugin_sbt1_2.12-${currentV}.jar""",
+          s"""test-plugin_2.12_1.0/${currentV}/test-plugin_2.12_1.0-${currentV}.jar""",
         ) => ()
     case Some(artifact) => sys.error(s"Unexpected artifact found: $artifact")
   }

--- a/src/sbt-test/write/consistent/build.sbt
+++ b/src/sbt-test/write/consistent/build.sbt
@@ -1,0 +1,36 @@
+import sbtconsistent.SbtConsistentPlugin.addConsistentSbtPlugin
+// cannot use the addSbtPlugin method cause it will add additional attributes which causes problems resolving.
+// we way want to use it as a global plugin when use it within enterprise.
+
+lazy val currentV = s"0.0.2${scala.util.Random.nextInt()}-SNAPSHOT"
+
+ThisBuild / version := currentV
+
+lazy val testPlugin = project.enablePlugins(SbtPlugin)
+  .enablePlugins(sbtconsistent.SbtConsistentPlugin).settings(
+    organization := "com.test",
+    name := "test-plugin",
+    publishMavenStyle := true,
+  )
+
+lazy val usePlugin = project.settings(
+  addConsistentSbtPlugin("com.test" % "test-plugin" % currentV),
+  resolvers += Resolver.mavenLocal,
+)
+
+TaskKey[Unit]("pub") := (testPlugin / publishM2).value
+
+TaskKey[Unit]("check") := {
+  val updateResult = (usePlugin / update).result.value
+  assert(updateResult.toEither.isRight, s"Expected success, got: $updateResult")
+  updateResult.toEither.toSeq.flatMap(_.toVector)
+    .find(_.toString.contains("test-plugin")) match {
+    case None => sys
+        .error(s"Could not find test-plugin artifact, have: $updateResult")
+    case Some(artifact)
+        if artifact.toString.contains(
+          s"""test-plugin_sbt1_2.12/0.0.2-SNAPSHOT/test-plugin_sbt1_2.12-${currentV}.jar""",
+        ) => ()
+    case Some(artifact) => sys.error(s"Unexpected artifact found: $artifact")
+  }
+}

--- a/src/sbt-test/write/consistent/project/build.properties
+++ b/src/sbt-test/write/consistent/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/src/sbt-test/write/consistent/project/plugins.sbt
+++ b/src/sbt-test/write/consistent/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("io.github.esbeetee" % "sbt-consistent" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/write/consistent/test
+++ b/src/sbt-test/write/consistent/test
@@ -1,0 +1,2 @@
+> pub
+> check

--- a/src/sbt-test/write/normal/build.sbt
+++ b/src/sbt-test/write/normal/build.sbt
@@ -1,0 +1,26 @@
+import sbtconsistent.SbtConsistentPlugin.addConsistentSbtPlugin
+// cannot use the addSbtPlugin method cause it will add additional attributes which causes problems resolving.
+// we way want to use it as a global plugin when use it within enterprise.
+
+lazy val currentV = s"0.0.2${scala.util.Random.nextInt()}-SNAPSHOT"
+
+ThisBuild / version := currentV
+
+lazy val testPlugin = project.enablePlugins(SbtPlugin)
+  .enablePlugins(sbtconsistent.SbtConsistentPlugin).settings(
+    organization := "com.test",
+    name := "test-plugin",
+    publishMavenStyle := true,
+  )
+
+lazy val usePlugin = project.settings(
+  addSbtPlugin("com.test" % "test-plugin" % currentV),
+  resolvers += Resolver.mavenLocal,
+)
+
+TaskKey[Unit]("pub") := (testPlugin / publishM2).value
+
+TaskKey[Unit]("check") := {
+  val updateResult = (usePlugin / update).result.value
+  assert(updateResult.toEither.isRight, s"Expected success, got: $updateResult")
+}

--- a/src/sbt-test/write/normal/build.sbt
+++ b/src/sbt-test/write/normal/build.sbt
@@ -2,7 +2,7 @@ import sbtconsistent.SbtConsistentPlugin.addConsistentSbtPlugin
 // cannot use the addSbtPlugin method cause it will add additional attributes which causes problems resolving.
 // we way want to use it as a global plugin when use it within enterprise.
 
-lazy val currentV = s"0.0.2${scala.util.Random.nextInt()}-SNAPSHOT"
+lazy val currentV = "0.0.412345156"
 
 ThisBuild / version := currentV
 
@@ -24,3 +24,4 @@ TaskKey[Unit]("check") := {
   val updateResult = (usePlugin / update).result.value
   assert(updateResult.toEither.isRight, s"Expected success, got: $updateResult")
 }
+

--- a/src/sbt-test/write/normal/project/build.properties
+++ b/src/sbt-test/write/normal/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/src/sbt-test/write/normal/project/plugins.sbt
+++ b/src/sbt-test/write/normal/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("io.github.esbeetee" % "sbt-consistent" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/write/normal/test
+++ b/src/sbt-test/write/normal/test
@@ -1,0 +1,2 @@
+> pub
+> check

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.4.5-SNAPSHOT"
+ThisBuild / version := "0.4.8-SNAPSHOT"


### PR DESCRIPTION
Add 2 scripted-level tests. Expectation in the tests follows:
- If we publish a plug-in, it should be accessible in a normal standard way
- If we publish a plug-in, it should be also accessible in a consistent way

This assumes that the publishing is done in a __single__ step in both cases (see below for the reason why).

Running the test `scripted write/consistent` showed:

```
[info] [info] Created a proper POM file: C:\Users\XYZ\AppData\Local\Temp\sbt_959e3e42\testPlugin\target\scala-2.12\sbt-1.0\test-plugin_sbt1_2.12.pom
[info] [info]   published test-plugin_sbt1_2.12 to file:/C:/Users/XYZ/.m2/repository/com/test/test-plugin_2.12_1.0/0.0.2-SNAPSHOT/test-plugin_sbt1_2.12-0.0.2-SNAPSHOT.jar
[info] [info]   published test-plugin_sbt1_2.12 to file:/C:/Users/XYZ/.m2/repository/com/test/test-plugin_2.12_1.0/0.0.2-SNAPSHOT/test-plugin_sbt1_2.12-0.0.2-SNAPSHOT-javadoc.jar
[info] [info]   published test-plugin_sbt1_2.12 to file:/C:/Users/XYZ/.m2/repository/com/test/test-plugin_2.12_1.0/0.0.2-SNAPSHOT/test-plugin_sbt1_2.12-0.0.2-SNAPSHOT-sources.jar
[info] [info]   published test-plugin_sbt1_2.12 to file:/C:/Users/XYZ/.m2/repository/com/test/test-plugin_2.12_1.0/0.0.2-SNAPSHOT/test-plugin_sbt1_2.12-0.0.2-SNAPSHOT.pom
Expected -->                                             C:\Users\XYZ\.m2\repository\com\test\test-plugin_sbt1_2.12\0.0.2-SNAPSHOT\test-plugin_sbt1_2.12-0.0.2-SNAPSHOT.pom

([info] [error]   not found: https://repo1.maven.org/maven2/com/test/test-plugin_sbt1_2.12/0.0.2-SNAPSHOT/test-plugin_sbt1_2.12-0.0.2-SNAPSHOT.pom)
```

Noticing here a couple of things: only the filename is affected, but it does not match the artifact ID (small change to fix this); the standard version is not published either.

This raises 2 important questions:

1. Do we publish consistent & inconsistent plug-ins in one command or two commands?
2. Should the artifactId be the same for both (ie. do we get two directories of 4 files each, or 1 directory of 8 published files)?

For sbt-assembly, Eugene Yokota published a convention of `sbt1_2.12` and published the module in a completely separate command.

My personal preference would be to:
- Publish in 1 command, so that plug-in authors don't have to think too much, especially from their CI pipelines.
- Publish with the same artifactId, so it is obvious that there are 2 different types of poms in the distribution; also this should simplify publishing to sonatype as you'd be publishing 1 artifactId.

Therefore, we'd need to change to _append_ rather than rewrite the list of artifacts; and also remove the sbt1_2.12 convention.