### PR TITLE
IfS issue: reproduce it

### DIFF
--- a/src/main/scala/sbtconsistent/SbtConsistentPlugin.scala
+++ b/src/main/scala/sbtconsistent/SbtConsistentPlugin.scala
@@ -70,6 +70,7 @@ object SbtConsistentPlugin extends AutoPlugin {
       artifacts += (makeProperPom / artifact).value,
 
       consistentPluginArtifacts :=
+        sbt.Def.ifS()
         (if (sbtPlugin.value) {
             Map(
               (Compile / packageBin / artifact).value.withName(sbtCrossArtifactName.value) -> (Compile / packageBin).value,

--- a/src/main/scala/sbtconsistent/SbtConsistentPlugin.scala
+++ b/src/main/scala/sbtconsistent/SbtConsistentPlugin.scala
@@ -70,7 +70,6 @@ object SbtConsistentPlugin extends AutoPlugin {
       artifacts += (makeProperPom / artifact).value,
 
       consistentPluginArtifacts :=
-        sbt.Def.ifS()
         (if (sbtPlugin.value) {
             Map(
               (Compile / packageBin / artifact).value.withName(sbtCrossArtifactName.value) -> (Compile / packageBin).value,

--- a/src/sbt-test/read/fail/project/build.properties
+++ b/src/sbt-test/read/fail/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.2.8

--- a/src/sbt-test/read/work/project/build.properties
+++ b/src/sbt-test/read/work/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.2.8

--- a/src/sbt-test/write/consistent/project/build.properties
+++ b/src/sbt-test/write/consistent/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.2.8

--- a/src/sbt-test/write/normal/project/build.properties
+++ b/src/sbt-test/write/normal/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.2.8


### PR DESCRIPTION
Reported via https://github.com/scalameta/sbt-scalafmt/pull/234#issuecomment-1200783599
Error is here: https://github.com/scalameta/sbt-scalafmt/runs/7604602427?check_suite_focus=true

When SBT processes the `if()`, in the plugin (where it checks for if the project is a plugin) it seems to have been updated more recently, ie does not work with SBT 1.2.6 for example.