### PR TITLE
Downgrade to SBT 1.2.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,6 @@ scriptedLaunchOpts := {
 
 scriptedBufferLog := false
 
-Global / onChangedBuildSource := ReloadOnSourceChanges
-
 description := "SBT plugin for publishing maven compatible POM for SBT plugins"
 developers := List(
   Developer(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.scalawilliam.esbeetee" % "sbt-vspp" % "0.4.11")
+//addSbtPlugin("com.scalawilliam.esbeetee" % "sbt-vspp" % "0.4.11")
 
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")


### PR DESCRIPTION
This is necessary to be compatible with a few important SBT plugins, such as [sbt-scalafmt](https://github.com/scalameta/sbt-scalafmt/pull/234).

Note that, in order for this to work, I had to:
- drop the sbt-vspp dependency: there is no 1.2.8 compatible version. This will need to be re-enabled as soon as possible.
- downgrade the release plugins significantly. I couldn't test these and have no idea whether that broke the release process.

Other than that, all tests pass.